### PR TITLE
Double trailing slash deleted

### DIFF
--- a/pages/ru/index.md
+++ b/pages/ru/index.md
@@ -38,7 +38,7 @@ description: "Git How To — это интерактивный тур, кото�
 
 <div class="col-sm-4">
 <h3><i class="fa fa-windows"></i> Windows</h3>
-<a href="http://git-for-windows.github.io//">git for windows</a>
+<a href="http://git-for-windows.github.io/">git for windows</a>
 </div>
 
 </div>


### PR DESCRIPTION
Double trailing slash replaced with single slash in git-for-windows.github.io link