### PR TITLE
typo

### DIFF
--- a/pages/en/pulling_shared_changes.md
+++ b/pages/en/pulling_shared_changes.md
@@ -21,5 +21,5 @@ title: "49. Removing common changes"
 
 <pre class="instructions">git remote add shared ../hello.git
 git branch --track shared master
-git pull
+git pull shared master
 cat README</pre>

--- a/pages/pt-BR/pulling_shared_changes.md
+++ b/pages/pt-BR/pulling_shared_changes.md
@@ -21,5 +21,5 @@ title: "49. Removendo modifica&ccedil;&otilde;es comuns"
 
 <pre class="instructions">git remote add shared ../hello.git
 git branch --track shared master
-git pull
+git pull shared master
 cat README</pre>

--- a/pages/ru/pulling_shared_changes.md
+++ b/pages/ru/pulling_shared_changes.md
@@ -21,5 +21,5 @@ title: "49. Извлечение общих изменений"
 
 <pre class="instructions">git remote add shared ../hello.git
 git branch --track shared master
-git pull
+git pull shared master
 cat README</pre>

--- a/pages/uk/pulling_shared_changes.md
+++ b/pages/uk/pulling_shared_changes.md
@@ -21,5 +21,5 @@ title: "49. Витяг загальних змін"
 
 <pre class="instructions">git remote add shared ../hello.git
 git branch --track shared master
-git pull
+git pull shared master
 cat README</pre>


### PR DESCRIPTION
When 'git pull' happens, the changes pull from 'origin'(../hello) instead of 'shared'(../hello.git), although this example shows dealing with 'shared' repository, but not 'origin'.