### PR TITLE
wrong setting that blocks CRLF to LF convertation

### DIFF
--- a/pages/en/setup.md
+++ b/pages/en/setup.md
@@ -23,11 +23,11 @@ git config --global user.email "your_email@whatever.com"</pre>
 <h4 class="h4-pre">Run:</h4>
 
 <pre class="instructions">git config --global core.autocrlf input
-git config --global core.safecrlf true</pre>
+git config --global core.safecrlf warn</pre>
 
 <p>For Windows users:</p>
 
 <h4 class="h4-pre">Run:</h4>
 
 <pre class="instructions">git config --global core.autocrlf true
-git config --global core.safecrlf true</pre>
+git config --global core.safecrlf warn</pre>

--- a/pages/pt-BR/setup.md
+++ b/pages/pt-BR/setup.md
@@ -23,11 +23,11 @@ git config --global user.email "seu_email@qualquercoisa.com"</pre>
 <h4 class="h4-pre">Execute:</h4>
 
 <pre class="instructions">git config --global core.autocrlf input
-git config --global core.safecrlf true</pre>
+git config --global core.safecrlf warn</pre>
 
 <p>Para usu&aacute;rios do Windows:</p>
 
 <h4 class="h4-pre">Execute:</h4>
 
 <pre class="instructions">git config --global core.autocrlf true
-git config --global core.safecrlf true</pre>
+git config --global core.safecrlf warn</pre>

--- a/pages/ru/setup.md
+++ b/pages/ru/setup.md
@@ -23,14 +23,14 @@ git config --global user.email "your_email@whatever.com"</pre>
 <h4 class="h4-pre">Выполнить:</h4>
 
 <pre class="instructions">git config --global core.autocrlf input
-git config --global core.safecrlf true</pre>
+git config --global core.safecrlf warn</pre>
 
 <p>Для пользователей Windows:</p>
 
 <h4 class="h4-pre">Выполнить:</h4>
 
 <pre class="instructions">git config --global core.autocrlf true
-git config --global core.safecrlf true</pre>
+git config --global core.safecrlf warn</pre>
 
 
 <h2><em>03</em> Установка отображения unicode</h2>

--- a/pages/uk/setup.md
+++ b/pages/uk/setup.md
@@ -23,11 +23,11 @@ git config --global user.email "your_email@whatever.com"</pre>
 <h4 class="h4-pre">Виконайте:</h4>
 
 <pre class="instructions">git config --global core.autocrlf input
-git config --global core.safecrlf true</pre>
+git config --global core.safecrlf warn</pre>
 
 <p>Для користувачів Windows:</p>
 
 <h4 class="h4-pre">Виконайте:</h4>
 
 <pre class="instructions">git config --global core.autocrlf true
-git config --global core.safecrlf true</pre>
+git config --global core.safecrlf warn</pre>


### PR DESCRIPTION
If you set both `autocrlf` and `safecrlf` options to `true` you could have some problems with commiting because `safecrlf` won't let you do convertation in some case.

So I believe that the best practice would be **not to set `safecrlf` to `true`**.

$ git config --global core.autocrlf true
$ git config --global core.safecrlf true
$ echo test >> LFtoCRLF
$ git add LFtoCRLF
**fatal: LF would be replaced by CRLF in LFtoCRLF**