### PR TITLE
Fix typo in en/removing_commits_from_a_branch

### DIFF
--- a/pages/en/removing_commits_from_a_branch.md
+++ b/pages/en/removing_commits_from_a_branch.md
@@ -45,7 +45,7 @@ title: "17. Removing a commit from a branch"
 
 <h2><em>03</em> Mark this branch first</h2>
 
-<p>Let us mark the last commit with <code>tag</tag>, so you can find it after removing a commit(s).</p>
+<p>Let us mark the last commit with <code>tag</code>, so you can find it after removing a commit(s).</p>
 
 <h4 class="h4-pre">Run:</h4>
 


### PR DESCRIPTION
Correct the closing tag on a code element, which was impacting the page rendering (due to automatic corrections by the browser).